### PR TITLE
fix: add copyright header to PLYReaderTest + update AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -414,6 +414,28 @@ public class Example
 - **Logging**: use `@Slf4j` annotation, then `log.info(...)`, `log.atError().setCause(ex).log(...)`.
 - **i18n**: use `Translate.text("key")` for user-visible strings, `Translate.menu("key")` for menus.
 
+### Copyright Headers
+
+Every new or substantially modified Java file **must** start with the project's GPL-2.0+ copyright header:
+
+```java
+/* Copyright (C) YYYY by Original Author Name
+ *  Changes copyright (C) YYYY by <Your Real Name>
+
+   This program is free software; you can redistribute it and/or modify it under the
+   terms of the GNU General Public License as published by the Free Software
+   Foundation; either version 2 of the License, or (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+   PARTICULAR PURPOSE.  See the GNU General Public License for more details. */
+```
+
+- When creating a **new file**, use `Copyright (C) YYYY by <Your Real Name>` as the sole author.
+- When modifying an **existing file**, keep the original `Copyright` line and add `Changes copyright (C) YYYY by <Your Real Name>`.
+- Use your real name, not a GitHub handle.
+- See `Polymesh/src/main/java/artofillusion/polymesh/AdvancedBevelExtrudeTool.java` for an example.
+
 ---
 
 ## 8. Pitfalls & Gotchas

--- a/Translators/src/test/java/artofillusion/translators/PLYReaderTest.java
+++ b/Translators/src/test/java/artofillusion/translators/PLYReaderTest.java
@@ -1,15 +1,33 @@
+/* Copyright (C) 2026 by Maksim Khramov
+ *  Changes copyright (C) 2026 by Alexander Vorobyev
+
+   This program is free software; you can redistribute it and/or modify it under the
+   terms of the GNU General Public License as published by the Free Software
+   Foundation; either version 2 of the License, or (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+   PARTICULAR PURPOSE.  See the GNU General Public License for more details. */
+
 package artofillusion.translators;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Paths;
 
 public class PLYReaderTest {
 
     @Test
-    void airplane() throws IOException {
-
-        var airplane = PLYReader.read("C:\\Work Files\\GitHub\\Tokonga\\Translators\\src\\test\\resources\\artofillusion\\translators\\airplane.ply");
-
+    void airplane() throws IOException, URISyntaxException {
+        var resource = getClass().getClassLoader()
+            .getResource("artofillusion/translators/airplane.ply");
+        Assertions.assertNotNull(resource, "airplane.ply not found in classpath");
+        var airplane = PLYReader.read(Paths.get(resource.toURI()).toString());
+        Assertions.assertNotNull(airplane, "PLYReader should return non-null object");
+        Assertions.assertEquals(2452, airplane.getFaceCount());
+        Assertions.assertEquals(1335, airplane.getVertices().length);
     }
 }


### PR DESCRIPTION
Supersedes #304 (auto-closed after branch was accidentally reset to main).

## What

- **PLYReaderTest.java**: replace hardcoded Windows path with classpath resource loading, add GPL-2.0+ copyright header with `Changes copyright` line
- **AGENTS.md**: add Copyright Headers section with generic guidelines (`<Your Real Name>` placeholder)

## Verification

`./gradlew :Translators:test` passes in Docker.

Closes #300