### PR TITLE
fix(tests): initialize ThemeManager for EditingTool unit tests (86 tests fixed)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -481,6 +481,31 @@ Every new or substantially modified Java file **must** start with the project's 
 - **Best covered**: `StandardModules` (procedural), `Filters`, `Translators`
 - **CI**: builds on macOS, does NOT run tests — always test locally
 - **Test location**: each module's `src/test/java/`
+- **Checkstyle**: `./gradlew checkstyleTest` — configured in `buildSrc/aoi.java-conventions`. Only warnings are enforced (no errors).
+
+### ThemeManager in Tests
+
+`ThemeManager` is global, mutable GUI state. It **must** be initialized before any
+`EditingTool` subclass is constructed, because tool constructors call
+`ThemeManager.getToolButton()` which reads `selectedTheme.buttonClass`.
+
+**Initialization sequence:**
+1. `PluginRegistry.registerResource("UITheme", "default", classLoader, "artofillusion/Icons/defaultTheme.xml", null)`
+2. `ThemeManager.initThemes()` — parses registered UITheme resources, sets `selectedTheme` to the default theme.
+
+**Key gotchas:**
+- `initThemes()` throws `IllegalStateException` if called twice — not idempotent.
+- `registerResource()` throws `IllegalArgumentException` if the resource ID is already registered.
+- Both calls need **separate** try-catch blocks. Putting them in a single `try` means that if `registerResource` throws, `initThemes()` is skipped and `selectedTheme` stays null → NPE in every tool constructor.
+- Default theme XML lives in `default-theme-lib/src/main/resources/artofillusion/Icons/defaultTheme.xml`.
+
+**Test extension** (`artofillusion.test.util.SetupTheme`):
+A JUnit 5 `BeforeAllCallback` that registers the default theme and calls `initThemes()`
+with proper once-per-JVM guards. Any test class that constructs `EditingTool` subclasses
+**must** include `SetupTheme.class` in `@ExtendWith`.
+
+**Other test utilities** in `artofillusion.test.util`: `SetupLocale`, `SetupLookAndFeel`,
+`RegisterTestResources` (translates bundles), `SetupTheme`.
 
 ---
 

--- a/ArtOfIllusion/src/test/java/artofillusion/test/util/SetupTheme.java
+++ b/ArtOfIllusion/src/test/java/artofillusion/test/util/SetupTheme.java
@@ -33,9 +33,13 @@ public class SetupTheme implements BeforeAllCallback {
         if (registered.compareAndSet(false, true)) {
             try {
                 PluginRegistry.registerResource("UITheme", "default", ArtOfIllusion.class.getClassLoader(), "artofillusion/Icons/defaultTheme.xml", null);
-                ThemeManager.initThemes();
             } catch (IllegalArgumentException iae) {
                 // Already registered by application startup or previous test class
+            }
+            try {
+                ThemeManager.initThemes();
+            } catch (IllegalStateException ise) {
+                // Themes already initialized by previous test class
             }
         }
     }

--- a/ArtOfIllusion/src/test/java/artofillusion/tool/hint/TestToolsHints.java
+++ b/ArtOfIllusion/src/test/java/artofillusion/tool/hint/TestToolsHints.java
@@ -37,6 +37,7 @@ import artofillusion.animation.SkeletonTool;
 import artofillusion.test.util.RegisterTestResources;
 import artofillusion.test.util.SetupLocale;
 import artofillusion.test.util.SetupLookAndFeel;
+import artofillusion.test.util.SetupTheme;
 import artofillusion.texture.MoveUVViewTool;
 import artofillusion.ui.EditingTool;
 import artofillusion.ui.GenericTool;
@@ -49,7 +50,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  *
  * @author MaksK
  */
-@ExtendWith({SetupLocale.class, SetupLookAndFeel.class, RegisterTestResources.class})  
+@ExtendWith({SetupLocale.class, SetupLookAndFeel.class, RegisterTestResources.class, SetupTheme.class})  
 public class TestToolsHints {
 
 


### PR DESCRIPTION
## Problem

`ThemeManager.selectedTheme` is null when `EditingTool` constructors call `ThemeManager.getToolButton()` → NPE on `selectedTheme.buttonClass`.

**Verified: 86 tests fixed (103 → 17), 7 failure categories resolved (Cat 1, 3, 5, 10, 13).**

### Failure categories reference

| Cat | Root Cause | Tests | Status |
|:---:|------------|------:|--------|
| 1 | `selectedTheme.buttonClass` null (ThemeManager not init) | 78 | ✅ Fixed |
| 2 | `SplineMesh.texParam` null | 8 | ❌ Remaining |
| 3 | `ApplicationPreferences.getInteractiveSurfaceError()` NPE | 3 | ✅ Cascade-fixed |
| 4 | `ViewerCanvas.lineColor` null (Polymesh) | 3 | ❌ Remaining |
| 5 | IOException reading `.aoi` with missing material | 3 | ✅ Cascade-fixed |
| 6–7 | Exponential notation parsed incorrectly (`5e-2` → `5.0`) | 2 | ❌ Remaining |
| 8–9 | Long overflow/underflow parsing | 2 | ❌ Remaining |
| 10 | `IllegalStateException`: themes already initialized | 1 | ✅ Cascade-fixed |
| 11 | `LayoutWindowTest#initializationError` | 1 | ❌ Remaining |
| 12 | `SelectAllAndUndoTest#initializationError` | 1 | ❌ Remaining |
| 13 | `source.loader` null in `ThemeManager.getIconURL` | 1 | ✅ Cascade-fixed |

## Root Cause & Fix

**Two bugs in test infrastructure:**

1. **`SetupTheme.java`** — `PluginRegistry.registerResource()` and `ThemeManager.initThemes()` were in a single `try-catch(IllegalArgumentException)`. When `registerResource` throws because the resource was already registered by a prior test class, `initThemes()` is **skipped entirely**, leaving `selectedTheme = null`. Fix: split into independent try-catch blocks, with `initThemes()` catching `IllegalStateException` (thrown if themes already initialized).

2. **`TestToolsHints.java`** — Missing `SetupTheme.class` from `@ExtendWith`, unlike the other two test classes which already had it. Fix: add `SetupTheme.class` extension.

## Verification

Full suite in Docker (`make -C docker test`), deduplicated XML parse:

| Metric | Value |
|--------|------:|
| Total unique tests | 701 |
| ✅ Passed | 684 |
| ❌ Failed | 17 |

**Category 1 tests (78 tests, direct fix):**
- `TestToolWhichClicks`: 26 tests, 0 failures ✅
- `ToolWhichClicksTest`: 26 tests, 0 failures ✅
- `TestToolsHints`: 26 tests, 0 failures ✅

**Cascade-resolved categories (8 additional tests):**
- Cat 3: `ApplicationPreferences` NPE in `SplineMeshTest` — 3 tests ✅
- Cat 5: `SceneLoadTest` IOException with missing material — 3 tests ✅
- Cat 10: `EnvironmentDialogTest` IllegalStateException — 1 test ✅
- Cat 13: `TestToolsHelp` NPE `source.loader` null — 1 test ✅

**Remaining 17 failures (Categories 2, 4, 6-9, 11-12):**
- Cat 2: `SplineMeshTest` `texParam` null — 8 tests
- Cat 4: `PolyMeshTest` `ViewerCanvas.lineColor` null — 3 tests
- Cat 6-7: `DataMapParserDoubleTest` exponential notation — 2 tests
- Cat 8-9: `DataMapParseLongTest` Long overflow/underflow — 2 tests
- Cat 11: `LayoutWindowTest#initializationError` — 1 test
- Cat 12: `SelectAllAndUndoTest#initializationError` — 1 test

## Scope

- Only test infrastructure files changed (`src/test/java`). No production code touched.
- Part of the fix plan documented in `TOKONGA_TEST_FAILURES_FIX_PLAN.md`.
